### PR TITLE
feat(prospects): add event rule for prospects

### DIFF
--- a/.aws/package-lock.json
+++ b/.aws/package-lock.json
@@ -9,7 +9,7 @@
       "version": "1.0.0",
       "license": "MPL-2.0",
       "dependencies": {
-        "@pocket-tools/terraform-modules": "3.13.10"
+        "@pocket-tools/terraform-modules": "4.0.5"
       },
       "devDependencies": {
         "@types/node": "^16.11.22",
@@ -135,9 +135,9 @@
       }
     },
     "node_modules/@cdktf/provider-archive": {
-      "version": "0.5.27",
-      "resolved": "https://registry.npmjs.org/@cdktf/provider-archive/-/provider-archive-0.5.27.tgz",
-      "integrity": "sha512-MxNudfdr2rO8oPsOPCo+1uUenL9r/1AL0bopQfb+STVrFhVoj5v7qXm+0AjmI//rTSM5WDtmSm4WeDVmxKiGQg==",
+      "version": "0.5.46",
+      "resolved": "https://registry.npmjs.org/@cdktf/provider-archive/-/provider-archive-0.5.46.tgz",
+      "integrity": "sha512-oRD/ARSz/2v6blcUq9VzQ23m4kJQssTnxCQOiA2k/v1vgjv1M4IVDT3kmij8InQJJ5DSx/QP/fDKe9Qusy+Byw==",
       "engines": {
         "node": ">= 14.17.0"
       },
@@ -147,9 +147,9 @@
       }
     },
     "node_modules/@cdktf/provider-aws": {
-      "version": "8.0.12",
-      "resolved": "https://registry.npmjs.org/@cdktf/provider-aws/-/provider-aws-8.0.12.tgz",
-      "integrity": "sha512-w1IX4NAays5NK3uzU7vFURo8TkKHWpro/7mOCOMq4/kuxgk0Gmu6uTs+VrBrSSENz/fZJ8hMAjopRaM4zb9NRA==",
+      "version": "8.0.14",
+      "resolved": "https://registry.npmjs.org/@cdktf/provider-aws/-/provider-aws-8.0.14.tgz",
+      "integrity": "sha512-8gngy5YE0vUkqZOadt5uF2CK4dM20ozHbIFCpd77v8vqtkMaGflFJbi5blpZeozRgmE0oM2ME3LLgL0wQkBJ5g==",
       "engines": {
         "node": ">= 14.17.0"
       },
@@ -200,9 +200,9 @@
       }
     },
     "node_modules/@cdktf/provider-local": {
-      "version": "0.5.26",
-      "resolved": "https://registry.npmjs.org/@cdktf/provider-local/-/provider-local-0.5.26.tgz",
-      "integrity": "sha512-Y0nXP+M2tf4YMe8AgOXg0RRHZwlWjAc0Lt9pYvFZUt3v7o7f7Csn9qwwvNV0+F8WFdDX2xdTjmNHeViqetar0w==",
+      "version": "0.5.46",
+      "resolved": "https://registry.npmjs.org/@cdktf/provider-local/-/provider-local-0.5.46.tgz",
+      "integrity": "sha512-pDBUpoP0s6GW+eUOBhrXcSeAIFFDZluAmRYYKCij+wOBQgJCJ7BSN5MvIHA4gO7O/SwbKZ76Oz/2ReqdGds3Zg==",
       "engines": {
         "node": ">= 14.17.0"
       },
@@ -212,9 +212,9 @@
       }
     },
     "node_modules/@cdktf/provider-newrelic": {
-      "version": "0.5.142",
-      "resolved": "https://registry.npmjs.org/@cdktf/provider-newrelic/-/provider-newrelic-0.5.142.tgz",
-      "integrity": "sha512-dXKfe9wbkQfoWdauZkoQeauIl6XGRGb3xuRleGf9zWvIvrmSylirv8mNH916QX2QnnoMnPQAq3z/DoFD4uE94Q==",
+      "version": "0.5.267",
+      "resolved": "https://registry.npmjs.org/@cdktf/provider-newrelic/-/provider-newrelic-0.5.267.tgz",
+      "integrity": "sha512-4SWUoB+k+cPMxS37qD28hwZM/ZRhJYO9wKy8HCKBa7xLXJ+8+OO8BU20XASUJT28YRWvABB1GaoU+7D8LXMVPA==",
       "engines": {
         "node": ">= 14.17.0"
       },
@@ -236,9 +236,9 @@
       }
     },
     "node_modules/@cdktf/provider-pagerduty": {
-      "version": "0.5.27",
-      "resolved": "https://registry.npmjs.org/@cdktf/provider-pagerduty/-/provider-pagerduty-0.5.27.tgz",
-      "integrity": "sha512-8z+68GECawMiSb52zhI+IfvpD+or/AZEaDO2yMg3nDSoWit1jc4U9yvi9yEcmCX1e6BqA+C/59TpNIFNCQm8rA==",
+      "version": "0.5.47",
+      "resolved": "https://registry.npmjs.org/@cdktf/provider-pagerduty/-/provider-pagerduty-0.5.47.tgz",
+      "integrity": "sha512-VhA3x0ynG4049OflSgCQzDI2GUboDkwahX9WV15mfwTd5WniH9SL/3HLVj831/rvlNucblINvSslhU1OhDpxHg==",
       "engines": {
         "node": ">= 14.17.0"
       },
@@ -410,35 +410,24 @@
       }
     },
     "node_modules/@pocket-tools/terraform-modules": {
-      "version": "3.13.10",
-      "resolved": "https://registry.npmjs.org/@pocket-tools/terraform-modules/-/terraform-modules-3.13.10.tgz",
-      "integrity": "sha512-Ei2W7KhBlGkB8I5/xrvD/N9XQbqfu1RWi5Q500OB1gZtSNADh1LYXy/8jN0m/NkzKIAHCJd4j0rpO4e4MmUYSA==",
+      "version": "4.0.5",
+      "resolved": "https://registry.npmjs.org/@pocket-tools/terraform-modules/-/terraform-modules-4.0.5.tgz",
+      "integrity": "sha512-b0KbcWDODrG3HAsuABRYPvFaaxmQ0S8p3jlmbdnwWd4A2fvFaV6VOMYxX4VdIQlYVXi9srhe3Pt45gECagHUOg==",
       "dependencies": {
-        "@cdktf/provider-archive": "0.5.27",
-        "@cdktf/provider-aws": "8.0.12",
-        "@cdktf/provider-local": "0.5.26",
-        "@cdktf/provider-newrelic": "0.5.142",
+        "@cdktf/provider-archive": "0.5.46",
+        "@cdktf/provider-aws": "8.0.14",
+        "@cdktf/provider-local": "0.5.46",
+        "@cdktf/provider-newrelic": "0.5.267",
         "@cdktf/provider-null": "0.7.27",
-        "@cdktf/provider-pagerduty": "0.5.27",
+        "@cdktf/provider-pagerduty": "0.5.47",
         "@sinonjs/commons": "^1.8.3",
         "cdktf": "0.11.2",
         "cdktf-cli": "0.11.2",
-        "constructs": "10.1.42",
+        "constructs": "10.1.43",
         "parse-domain": "^4.1.0"
       },
       "engines": {
-        "node": ">=10.12"
-      },
-      "peerDependencies": {
-        "@cdktf/provider-archive": "0.5.27",
-        "@cdktf/provider-aws": "8.0.12",
-        "@cdktf/provider-local": "0.5.26",
-        "@cdktf/provider-newrelic": "0.5.142",
-        "@cdktf/provider-null": "0.7.27",
-        "@cdktf/provider-pagerduty": "0.5.27",
-        "cdktf": "0.11.2",
-        "cdktf-cli": "0.11.2",
-        "constructs": "10.1.42"
+        "node": ">=14"
       }
     },
     "node_modules/@sentry/core": {
@@ -1487,9 +1476,9 @@
       "integrity": "sha512-/Srv4dswyQNBfohGpz9o6Yb3Gz3SrUDqBH5rTuhGR7ahtlbYKnVxw2bCFMRljaA7EXHaXZ8wsHdodFvbkhKmqg=="
     },
     "node_modules/constructs": {
-      "version": "10.1.42",
-      "resolved": "https://registry.npmjs.org/constructs/-/constructs-10.1.42.tgz",
-      "integrity": "sha512-5AELa/PFtZG+WTjn9HoXhqsDZYV6l3J7Li9xw6vREYVMasF8cnVbTZvA4crP1gIyKtBAxAlnZCmzmCbicnH6eg==",
+      "version": "10.1.43",
+      "resolved": "https://registry.npmjs.org/constructs/-/constructs-10.1.43.tgz",
+      "integrity": "sha512-I7CEsYPmcsTpmf+tT3DZq5klCzk2d0Gb6X67P5XxYq0an4+JiWrf8/LCIHV3xqOhnGLAbM/aGZ3bigUNTWeliA==",
       "engines": {
         "node": ">= 14.17.0"
       }
@@ -3786,15 +3775,15 @@
       }
     },
     "@cdktf/provider-archive": {
-      "version": "0.5.27",
-      "resolved": "https://registry.npmjs.org/@cdktf/provider-archive/-/provider-archive-0.5.27.tgz",
-      "integrity": "sha512-MxNudfdr2rO8oPsOPCo+1uUenL9r/1AL0bopQfb+STVrFhVoj5v7qXm+0AjmI//rTSM5WDtmSm4WeDVmxKiGQg==",
+      "version": "0.5.46",
+      "resolved": "https://registry.npmjs.org/@cdktf/provider-archive/-/provider-archive-0.5.46.tgz",
+      "integrity": "sha512-oRD/ARSz/2v6blcUq9VzQ23m4kJQssTnxCQOiA2k/v1vgjv1M4IVDT3kmij8InQJJ5DSx/QP/fDKe9Qusy+Byw==",
       "requires": {}
     },
     "@cdktf/provider-aws": {
-      "version": "8.0.12",
-      "resolved": "https://registry.npmjs.org/@cdktf/provider-aws/-/provider-aws-8.0.12.tgz",
-      "integrity": "sha512-w1IX4NAays5NK3uzU7vFURo8TkKHWpro/7mOCOMq4/kuxgk0Gmu6uTs+VrBrSSENz/fZJ8hMAjopRaM4zb9NRA==",
+      "version": "8.0.14",
+      "resolved": "https://registry.npmjs.org/@cdktf/provider-aws/-/provider-aws-8.0.14.tgz",
+      "integrity": "sha512-8gngy5YE0vUkqZOadt5uF2CK4dM20ozHbIFCpd77v8vqtkMaGflFJbi5blpZeozRgmE0oM2ME3LLgL0wQkBJ5g==",
       "requires": {}
     },
     "@cdktf/provider-generator": {
@@ -3832,15 +3821,15 @@
       }
     },
     "@cdktf/provider-local": {
-      "version": "0.5.26",
-      "resolved": "https://registry.npmjs.org/@cdktf/provider-local/-/provider-local-0.5.26.tgz",
-      "integrity": "sha512-Y0nXP+M2tf4YMe8AgOXg0RRHZwlWjAc0Lt9pYvFZUt3v7o7f7Csn9qwwvNV0+F8WFdDX2xdTjmNHeViqetar0w==",
+      "version": "0.5.46",
+      "resolved": "https://registry.npmjs.org/@cdktf/provider-local/-/provider-local-0.5.46.tgz",
+      "integrity": "sha512-pDBUpoP0s6GW+eUOBhrXcSeAIFFDZluAmRYYKCij+wOBQgJCJ7BSN5MvIHA4gO7O/SwbKZ76Oz/2ReqdGds3Zg==",
       "requires": {}
     },
     "@cdktf/provider-newrelic": {
-      "version": "0.5.142",
-      "resolved": "https://registry.npmjs.org/@cdktf/provider-newrelic/-/provider-newrelic-0.5.142.tgz",
-      "integrity": "sha512-dXKfe9wbkQfoWdauZkoQeauIl6XGRGb3xuRleGf9zWvIvrmSylirv8mNH916QX2QnnoMnPQAq3z/DoFD4uE94Q==",
+      "version": "0.5.267",
+      "resolved": "https://registry.npmjs.org/@cdktf/provider-newrelic/-/provider-newrelic-0.5.267.tgz",
+      "integrity": "sha512-4SWUoB+k+cPMxS37qD28hwZM/ZRhJYO9wKy8HCKBa7xLXJ+8+OO8BU20XASUJT28YRWvABB1GaoU+7D8LXMVPA==",
       "requires": {}
     },
     "@cdktf/provider-null": {
@@ -3850,9 +3839,9 @@
       "requires": {}
     },
     "@cdktf/provider-pagerduty": {
-      "version": "0.5.27",
-      "resolved": "https://registry.npmjs.org/@cdktf/provider-pagerduty/-/provider-pagerduty-0.5.27.tgz",
-      "integrity": "sha512-8z+68GECawMiSb52zhI+IfvpD+or/AZEaDO2yMg3nDSoWit1jc4U9yvi9yEcmCX1e6BqA+C/59TpNIFNCQm8rA==",
+      "version": "0.5.47",
+      "resolved": "https://registry.npmjs.org/@cdktf/provider-pagerduty/-/provider-pagerduty-0.5.47.tgz",
+      "integrity": "sha512-VhA3x0ynG4049OflSgCQzDI2GUboDkwahX9WV15mfwTd5WniH9SL/3HLVj831/rvlNucblINvSslhU1OhDpxHg==",
       "requires": {}
     },
     "@jridgewell/gen-mapping": {
@@ -3975,20 +3964,20 @@
       }
     },
     "@pocket-tools/terraform-modules": {
-      "version": "3.13.10",
-      "resolved": "https://registry.npmjs.org/@pocket-tools/terraform-modules/-/terraform-modules-3.13.10.tgz",
-      "integrity": "sha512-Ei2W7KhBlGkB8I5/xrvD/N9XQbqfu1RWi5Q500OB1gZtSNADh1LYXy/8jN0m/NkzKIAHCJd4j0rpO4e4MmUYSA==",
+      "version": "4.0.5",
+      "resolved": "https://registry.npmjs.org/@pocket-tools/terraform-modules/-/terraform-modules-4.0.5.tgz",
+      "integrity": "sha512-b0KbcWDODrG3HAsuABRYPvFaaxmQ0S8p3jlmbdnwWd4A2fvFaV6VOMYxX4VdIQlYVXi9srhe3Pt45gECagHUOg==",
       "requires": {
-        "@cdktf/provider-archive": "0.5.27",
-        "@cdktf/provider-aws": "8.0.12",
-        "@cdktf/provider-local": "0.5.26",
-        "@cdktf/provider-newrelic": "0.5.142",
+        "@cdktf/provider-archive": "0.5.46",
+        "@cdktf/provider-aws": "8.0.14",
+        "@cdktf/provider-local": "0.5.46",
+        "@cdktf/provider-newrelic": "0.5.267",
         "@cdktf/provider-null": "0.7.27",
-        "@cdktf/provider-pagerduty": "0.5.27",
+        "@cdktf/provider-pagerduty": "0.5.47",
         "@sinonjs/commons": "^1.8.3",
         "cdktf": "0.11.2",
         "cdktf-cli": "0.11.2",
-        "constructs": "10.1.42",
+        "constructs": "10.1.43",
         "parse-domain": "^4.1.0"
       }
     },
@@ -4746,9 +4735,9 @@
       "integrity": "sha512-/Srv4dswyQNBfohGpz9o6Yb3Gz3SrUDqBH5rTuhGR7ahtlbYKnVxw2bCFMRljaA7EXHaXZ8wsHdodFvbkhKmqg=="
     },
     "constructs": {
-      "version": "10.1.42",
-      "resolved": "https://registry.npmjs.org/constructs/-/constructs-10.1.42.tgz",
-      "integrity": "sha512-5AELa/PFtZG+WTjn9HoXhqsDZYV6l3J7Li9xw6vREYVMasF8cnVbTZvA4crP1gIyKtBAxAlnZCmzmCbicnH6eg=="
+      "version": "10.1.43",
+      "resolved": "https://registry.npmjs.org/constructs/-/constructs-10.1.43.tgz",
+      "integrity": "sha512-I7CEsYPmcsTpmf+tT3DZq5klCzk2d0Gb6X67P5XxYq0an4+JiWrf8/LCIHV3xqOhnGLAbM/aGZ3bigUNTWeliA=="
     },
     "convert-to-spaces": {
       "version": "1.0.2",

--- a/.aws/package.json
+++ b/.aws/package.json
@@ -16,7 +16,7 @@
     "node": "=12"
   },
   "dependencies": {
-    "@pocket-tools/terraform-modules": "3.13.10"
+    "@pocket-tools/terraform-modules": "4.0.5"
   },
   "devDependencies": {
     "@types/node": "^16.11.22",

--- a/.aws/src/event-rules/prospect-events/eventConfig.ts
+++ b/.aws/src/event-rules/prospect-events/eventConfig.ts
@@ -1,0 +1,4 @@
+export const eventConfig = {
+  source: 'prospect-events',
+  detailType: ['prospect-generation'],
+};

--- a/.aws/src/event-rules/prospect-events/prospectEventRules.ts
+++ b/.aws/src/event-rules/prospect-events/prospectEventRules.ts
@@ -1,0 +1,122 @@
+import { Construct } from 'constructs';
+import { Resource } from 'cdktf';
+import {
+  PocketEventBridgeProps,
+  PocketEventBridgeRuleWithMultipleTargets,
+  ApplicationEventBus,
+  PocketEventBridgeTargets,
+} from '@pocket-tools/terraform-modules';
+import { config } from '../../config';
+import { iam, sns, sqs } from '@cdktf/provider-aws';
+import { eventConfig } from './eventConfig';
+
+/**
+ * Purpose:
+ * 
+ * The purpose of this rule set is to send ML-generated prospects to two
+ * separate systems:
+ * 
+ * 1. A pre-existing production SQS queue that is consumed by a lambda which
+ * feeds those prospects to the curation admin tool.
+ * 
+ * 2. The dev instance of this event bridge, which will in turn send the
+ * prospects to the dev SQS queue to be consumed by the dev lambda and sent
+ * to the dev curation admin tool :D
+ * 
+ * Note that this class behaves differently based on the environment to which
+ * it was deployed!
+ */
+export class ProspectEvents extends Resource {
+  public readonly snsTopic: sns.SnsTopic;
+  public readonly sqs: sqs.DataAwsSqsQueue;
+  public readonly sqsDlq: sqs.DataAwsSqsQueue;
+
+  constructor(
+    scope: Construct,
+    private name: string,
+    private sharedEventBus: ApplicationEventBus
+  ) {
+    super(scope, name);
+
+    // pre-existing queues (prod and dev) created by prospect-api
+    this.sqs = new sqs.DataAwsSqsQueue(this, `prospect-${config.environment}-queue`, {
+      name: `ProspectAPI-${config.environment}-Sqs-Translation-Queue`
+    })
+
+    this.sqsDlq = new sqs.DataAwsSqsQueue(this, `prospect-${config.environment}-dlq`, {
+      name: `ProspectAPI-${config.environment}-Sqs-Translation-Queue-Deadletter`
+    });
+
+    this.createProspectEventRules();
+    this.createPolicyForEventBridgeToSqs();
+
+    // TODO: create a policy function for dev event bridge
+    // this.createPolicyForEventBridgeToDevEventBridge();
+  }
+
+  /**
+   * Create an event bridge rule and attach to the configured targets.
+   * @private
+   */
+  private createProspectEventRules() {
+    // both prod and dev have an sqs target
+    const targets: PocketEventBridgeTargets[] = [
+      {
+          arn: this.sqs.arn,
+          deadLetterArn: this.sqsDlq.arn,
+          targetId: `${config.prefix}-Prospect-Event-SQS-Target`,
+        },
+    ];
+
+    // only prod also targets the dev event bridge
+    if (!config.isDev) {
+      // TODO: add dev event bridge target
+      // https://docs.aws.amazon.com/eventbridge/latest/userguide/eb-cross-account.html
+    }
+
+    const prospectEventRuleProps: PocketEventBridgeProps = {
+      eventRule: {
+        name: `${config.prefix}-ProspectEvents-Rule`,
+        pattern: {
+          source: [eventConfig.source],
+          'detail-type': eventConfig.detailType,
+        },
+        eventBusName: this.sharedEventBus.bus.name,
+      },
+      targets,
+    };
+
+    new PocketEventBridgeRuleWithMultipleTargets(
+      this,
+      `${config.prefix}-Prospect-Prod-EventBridge-Rule`,
+      prospectEventRuleProps
+    );
+  }
+
+  private createPolicyForEventBridgeToSqs() {
+    const eventBridgeSqsPolicy = new iam.DataAwsIamPolicyDocument(
+      this,
+      `${config.prefix}-EventBridge-Prospect-Event-SQS-Policy`,
+      {
+        statement: [
+          {
+            effect: 'Allow',
+            actions: ['sqs:SendMessage'],
+            resources: [this.sqs.arn],
+            principals: [
+              {
+                identifiers: ['events.amazonaws.com'],
+                type: 'Service',
+              },
+            ],
+          },
+        ],
+      }
+    ).json;
+
+    new sqs.SqsQueuePolicy(this, 'prospect-events-sqs-policy', {
+      policy: eventBridgeSqsPolicy,
+      queueUrl: this.sqs.url
+    });
+  }
+}

--- a/.aws/src/event-rules/user-api-events/userApiEventRules.ts
+++ b/.aws/src/event-rules/user-api-events/userApiEventRules.ts
@@ -43,7 +43,7 @@ export class UserApiEvents extends Resource {
         name: `${config.prefix}-UserEvents-Rule`,
         pattern: {
           source: [eventConfig.source],
-          'detail-type': [...eventConfig.detailType],
+          'detail-type': eventConfig.detailType,
         },
         eventBusName: this.sharedEventBus.bus.name,
       },
@@ -59,7 +59,7 @@ export class UserApiEvents extends Resource {
 
     return new PocketEventBridgeRuleWithMultipleTargets(
       this,
-      `${config.prefix}-EventBridge-Rule`,
+      `${config.prefix}-User-Api-EventBridge-Rule`,
       userEventRuleProps
     );
   }

--- a/.aws/src/events-schema/userEvents.ts
+++ b/.aws/src/events-schema/userEvents.ts
@@ -4,7 +4,6 @@ import { eventbridgeschemas } from '@cdktf/provider-aws';
 import { SCHEMA_REGISTRY, SCHEMA_TYPE } from './types';
 import { SchemasSchemaConfig } from '@cdktf/provider-aws/lib/eventbridgeschemas/schemas-schema';
 
-
 export class UserEventsSchema extends Resource {
   constructor(
     scope: Construct,
@@ -13,7 +12,6 @@ export class UserEventsSchema extends Resource {
     super(scope, name);
     this.createUserEventsSchema()
   }
-
 
   private createUserEventsSchema() {
     const schemaProps: SchemasSchemaConfig = {


### PR DESCRIPTION
## Goal

create event bridge rule for prospects coming in from ML processes.

this is PHASE 1 of this change. deploying this to production will not have any impact until we update ML systems to send prospects to event bridge instead of SQS - but this can (and should!) still go out to prod!

PHASE 2 will satisfy the `TODO`s left in this PR - the effect of which will be any prospects sent to the prod event bridge will be sent to the dev event bridge (which will in turn send them to the dev sqs queue and the dev curation admin tools prospect db).

this has successfully been deployed to dev and tested there. it successfully sends events down to the dev sqs queue and i'm seeing the logs in the dev lambda!

## References

JIRA ticket:
* https://getpocket.atlassian.net/browse/BACK-1412