### PR TITLE
fix: change queue to EventTracker queue

### DIFF
--- a/.aws/src/event-rules/account-delete-monitor/config.ts
+++ b/.aws/src/event-rules/account-delete-monitor/config.ts
@@ -1,11 +1,11 @@
-import { config as globalConfig} from '../../config'
+import { config as globalConfig } from '../../config';
 
 export const config = {
-    queueCheckDelete: {
-        scheduleExpression: 'cron(15 10 * * ? *)', // 03:15 PT every day
-        name: 'QueueCheckDelete',
-        schema: 'queue-check-delete',
-        bus: 'default',
-    },
-    prefix: `AccountDeleteMonitor-${globalConfig.environment}`
-  };
+  queueCheckDelete: {
+    scheduleExpression: 'cron(15 10 * * ? *)', // 03:15 PT every day
+    name: 'EventTracker',
+    schema: 'queue-check-delete',
+    bus: 'default',
+  },
+  prefix: `AccountDeleteMonitor-${globalConfig.environment}`,
+};

--- a/.aws/src/main.ts
+++ b/.aws/src/main.ts
@@ -57,9 +57,6 @@ class PocketEventBus extends TerraformStack {
       sharedPocketEventBus
     );
 
-    // publish user api schema to event registry
-    new UserEventsSchema(this, 'user-api-events-schema');
-
     new SnowplowConsumer(
       this,
       'pocket-snowplow-consumer',
@@ -73,6 +70,9 @@ class PocketEventBus extends TerraformStack {
 
     // Events for Account Delete Monitor service
     new AccountDeleteMonitorEvents(this, 'adm-events');
+
+    //Schema
+    new UserEventsSchema(this, 'user-api-events-schema');
     new QueueCheckDeleteSchema(this, 'queue-delete-schema');
     new UserMergeEventSchema(this, 'user-merge-event-shema');
   }


### PR DESCRIPTION
## Goal
The queuename is changed in ADM
reflecting this name change in check-delete event rule

Dev deployment: https://us-east-1.console.aws.amazon.com/codesuite/codebuild/410318598490/projects/PocketEventBridge-Dev/build/PocketEventBridge-Dev%3A1ef7912b-b6a4-40d5-832c-f6a5d63006ec/?region=us-east-1

slack thread: https://pocket.slack.com/archives/C03QVL4SU/p1660150733742039

TODO: re-play events from morning in both the event bus after merging