### PR TITLE
feat: add premium purchase event schema to registry

### DIFF
--- a/.aws/src/events-schema/premiumPurchaseEvent.ts
+++ b/.aws/src/events-schema/premiumPurchaseEvent.ts
@@ -1,0 +1,118 @@
+/**
+ * PremiumPurchase event is emitted when a pocket user has subscribed for
+ * premium account.
+ */
+import { Resource, Fn } from 'cdktf';
+import { Construct } from 'constructs';
+import { eventbridgeschemas } from '@cdktf/provider-aws';
+import { SCHEMA_REGISTRY, SCHEMA_TYPE } from './types';
+import { SchemasSchemaConfig } from '@cdktf/provider-aws/lib/eventbridgeschemas/schemas-schema';
+
+export class PremiumPurchaseEvent extends Resource {
+  public readonly eventName: string = 'premium-purchase';
+
+  constructor(scope: Construct, private name: string) {
+    super(scope, name);
+    this.createPremiumPurchaseEvent();
+  }
+
+  private createPremiumPurchaseEvent() {
+    const schemaProps: SchemasSchemaConfig = {
+      name: this.eventName,
+      description: `emitted when pocket user subscribes for premium account`,
+      type: SCHEMA_TYPE,
+      registryName: SCHEMA_REGISTRY,
+      content: Fn.jsonencode(this.getPremiumPurchaseEventSchema()),
+    };
+    const schema = new eventbridgeschemas.SchemasSchema(
+      this,
+      `${this.eventName}-schema`,
+      schemaProps
+    );
+    return schema;
+  }
+
+  /***
+   * Schema scaffold from the aws console
+   */
+  private getPremiumPurchaseEventSchema() {
+    return {
+      openapi: '3.0.0',
+      info: {
+        version: '1.0.0',
+        title: 'Event',
+      },
+      paths: {},
+      components: {
+        schemas: {
+          Event: {
+            type: 'object',
+            required: ['purchase', 'user'],
+            properties: {
+              purchase: {
+                $ref: '#/components/schemas/Purchase',
+              },
+              user: {
+                $ref: '#/components/schemas/User',
+              },
+            },
+          },
+          Purchase: {
+            type: 'object',
+            required: [
+              'amount',
+              'planType',
+              'isFree',
+              'planInterval',
+              'cancelAtPeriodEnd',
+              'isTrial',
+              'receiptId',
+              'renewDate',
+            ],
+            properties: {
+              amount: {
+                type: 'string',
+              },
+              cancelAtPeriodEnd: {
+                type: 'boolean',
+              },
+              isFree: {
+                type: 'boolean',
+              },
+              isTrial: {
+                type: 'boolean',
+              },
+              planInterval: {
+                type: 'string',
+              },
+              planType: {
+                type: 'string',
+              },
+              receiptId: {
+                type: 'string',
+              },
+              renewDate: {
+                type: 'string',
+              },
+            },
+          },
+          User: {
+            type: 'object',
+            required: ['id', 'encodedId', 'email'],
+            properties: {
+              email: {
+                type: 'string',
+              },
+              encodedId: {
+                type: 'string',
+              },
+              id: {
+                type: 'number',
+              },
+            },
+          },
+        },
+      },
+    };
+  }
+}

--- a/.aws/src/events-schema/premiumPurchaseEvent.ts
+++ b/.aws/src/events-schema/premiumPurchaseEvent.ts
@@ -22,7 +22,7 @@ export class PremiumPurchaseEvent extends Resource {
       description: `emitted when pocket user subscribes for premium account`,
       type: SCHEMA_TYPE,
       registryName: SCHEMA_REGISTRY,
-      content: Fn.jsonencode(this.getPremiumPurchaseEventSchema())
+      content: JSON.stringify(this.getPremiumPurchaseEventSchema())
     };
     const schema = new eventbridgeschemas.SchemasSchema(
       this,

--- a/.aws/src/events-schema/premiumPurchaseEvent.ts
+++ b/.aws/src/events-schema/premiumPurchaseEvent.ts
@@ -22,7 +22,7 @@ export class PremiumPurchaseEvent extends Resource {
       description: `emitted when pocket user subscribes for premium account`,
       type: SCHEMA_TYPE,
       registryName: SCHEMA_REGISTRY,
-      content: Fn.jsonencode(this.getPremiumPurchaseEventSchema()),
+      content: Fn.jsonencode(this.getPremiumPurchaseEventSchema())
     };
     const schema = new eventbridgeschemas.SchemasSchema(
       this,
@@ -37,82 +37,74 @@ export class PremiumPurchaseEvent extends Resource {
    */
   private getPremiumPurchaseEventSchema() {
     return {
-      openapi: '3.0.0',
-      info: {
-        version: '1.0.0',
-        title: 'Event',
+      "openapi": "3.0.0",
+      "info": {
+        "version": "1.0.0",
+        "title": "Event"
       },
-      paths: {},
-      components: {
-        schemas: {
-          Event: {
-            type: 'object',
-            required: ['purchase', 'user'],
-            properties: {
-              purchase: {
-                $ref: '#/components/schemas/Purchase',
+      "paths": {},
+      "components": {
+        "schemas": {
+          "Event": {
+            "type": "object",
+            "required": ["purchase", "user"],
+            "properties": {
+              "purchase": {
+                "$ref": "#/components/schemas/Purchase"
               },
-              user: {
-                $ref: '#/components/schemas/User',
-              },
-            },
+              "user": {
+                "$ref": "#/components/schemas/User"
+              }
+            }
           },
-          Purchase: {
-            type: 'object',
-            required: [
-              'amount',
-              'planType',
-              'isFree',
-              'planInterval',
-              'cancelAtPeriodEnd',
-              'isTrial',
-              'receiptId',
-              'renewDate',
-            ],
-            properties: {
-              amount: {
-                type: 'string',
+          "Purchase": {
+            "type": "object",
+            "required": ["amount", "planType", "isFree", "planInterval", "cancelAtPeriodEnd", "isTrial", "receiptId", "renewDate"],
+            "properties": {
+              "amount": {
+                "type": "string"
               },
-              cancelAtPeriodEnd: {
-                type: 'boolean',
+              "cancelAtPeriodEnd": {
+                "type": "boolean"
               },
-              isFree: {
-                type: 'boolean',
+              "isFree": {
+                "type": "boolean"
               },
-              isTrial: {
-                type: 'boolean',
+              "isTrial": {
+                "type": "boolean"
               },
-              planInterval: {
-                type: 'string',
+              "planInterval": {
+                "type": "string"
               },
-              planType: {
-                type: 'string',
+              "planType": {
+                "type": "string"
               },
-              receiptId: {
-                type: 'string',
+              "receiptId": {
+                "type": "string"
               },
-              renewDate: {
-                type: 'string',
-              },
-            },
+              "renewDate": {
+                "type": "string"
+              }
+            }
           },
-          User: {
-            type: 'object',
-            required: ['id', 'encodedId', 'email'],
-            properties: {
-              email: {
-                type: 'string',
+          "User": {
+            "type": "object",
+            "required": ["id", "encodedId", "email"],
+            "properties": {
+              "email": {
+                "type": "string"
               },
-              encodedId: {
-                type: 'string',
+              "encodedId": {
+                "type": "string"
               },
-              id: {
-                type: 'number',
-              },
-            },
-          },
-        },
-      },
+              "id": {
+                "type": "number"
+              }
+            }
+          }
+        }
+      }
     };
   }
 }
+

--- a/.aws/src/main.ts
+++ b/.aws/src/main.ts
@@ -18,6 +18,7 @@ import { UserEventsSchema } from './events-schema/userEvents';
 import { AccountDeleteMonitorEvents } from './event-rules/account-delete-monitor';
 import { QueueCheckDeleteSchema } from './events-schema/queueCheckDelete';
 import { UserMergeEventSchema } from './events-schema/userMergeEvent';
+import { PremiumPurchaseEvent } from './events-schema/premiumPurchaseEvent';
 
 class PocketEventBus extends TerraformStack {
   constructor(scope: Construct, name: string) {
@@ -75,6 +76,7 @@ class PocketEventBus extends TerraformStack {
     new UserEventsSchema(this, 'user-api-events-schema');
     new QueueCheckDeleteSchema(this, 'queue-delete-schema');
     new UserMergeEventSchema(this, 'user-merge-event-shema');
+    new PremiumPurchaseEvent(this, 'premium-purchase-event-schema');
   }
 }
 


### PR DESCRIPTION
## Goal
add premium purchase event schema to registry

[payload in web ]( https://github.com/Pocket/Web/blob/9bc25813fa0f37e4cefae6a4c6f8efc4d53bb138/tests/functional/AWS/EventBridge/SubscriberTest.php#L59
)
[dev deployment](https://us-east-1.console.aws.amazon.com/events/home?region=us-east-1#/registries/PocketEventBus/schemas/premium-purchase)

Ticket: [infra-741](https://getpocket.atlassian.net/browse/INFRA-741)