### PR TITLE
feat(send to dev): send prospect events to dev bus

### DIFF
--- a/.aws/src/event-rules/prospect-events/prospectEventRules.ts
+++ b/.aws/src/event-rules/prospect-events/prospectEventRules.ts
@@ -70,8 +70,13 @@ export class ProspectEvents extends Resource {
 
     // only prod also targets the dev event bridge
     if (!config.isDev) {
-      // TODO: add dev event bridge target
       // https://docs.aws.amazon.com/eventbridge/latest/userguide/eb-cross-account.html
+      // note that permissions have been added by hand to the dev event bus to
+      // allow it to receive events from the prod bus.
+      targets.push({
+        arn: 'arn:aws:events:us-east-1:410318598490:event-bus/PocketEventBridge-Dev-Shared-Event-Bus',
+        targetId: `${config.prefix}-Prospect-Event-Dev-Event-Bridget-Target`
+      })
     }
 
     const prospectEventRuleProps: PocketEventBridgeProps = {


### PR DESCRIPTION
## Goal

send prospect events to the dev bus.

## Implementation Decisions
- manually added permissions to the dev bus instead of updating terraform modules to allow this config. chose this because 1) this is our only use case for cross-account posting at this time, and 2) if the dev permissions go away, it's fine to manually recreate them (not system-critical)

## References

JIRA ticket:
* https://getpocket.atlassian.net/browse/BACK-1549