### PR TITLE
feat(dismissProspect): [BACK-1623] add event rule and sns topic for dismiss prospect event

### DIFF
--- a/.aws/src/event-rules/prospect-events/eventConfig.ts
+++ b/.aws/src/event-rules/prospect-events/eventConfig.ts
@@ -1,8 +1,10 @@
 export const eventConfig = {
-  source: 'prospect-events',
-  detailType: ['prospect-generation'],
-  dismissProspect: {
+  prospectGeneration: {
     source: 'prospect-events',
-    detailType: ['dismiss-prospect'],
+    detailType: ['prospect-generation'],
+  },
+  prospectDismiss: {
+    source: 'prospect-events',
+    detailType: ['prospect-dismiss'],
   },
 };

--- a/.aws/src/event-rules/prospect-events/prospectEventRules.ts
+++ b/.aws/src/event-rules/prospect-events/prospectEventRules.ts
@@ -69,7 +69,7 @@ export class ProspectEvents extends Resource {
 
     // setting up prospect-dismiss event rule
     this.createProspectEventRule(
-      'Dismiss-Prospect-Events-Rule',
+      'Prospect-Dismiss',
       eventConfig.prospectDismiss.source,
       eventConfig.prospectDismiss.detailType
     );
@@ -181,7 +181,7 @@ export class ProspectEvents extends Resource {
 
     const prospectEventRuleProps = {
       eventRule: {
-        name: `${config.prefix}-${name}`,
+        name: `${config.prefix}-${name}-Event-Rule`,
         eventPattern: {
           source: [source],
           'detail-type': detailType,

--- a/.aws/src/event-rules/prospect-events/prospectEventRules.ts
+++ b/.aws/src/event-rules/prospect-events/prospectEventRules.ts
@@ -14,7 +14,7 @@ import { eventConfig } from './eventConfig';
  * Purposes:
  *
  * 1. Set up a rule set to send ML-generated prospects to two
- * separate systems:
+ * separate systems (prospect-generation event):
  *
  *    a. A pre-existing production SQS queue that is consumed by a lambda which
  *       feeds those prospects to the curation admin tool.
@@ -23,7 +23,7 @@ import { eventConfig } from './eventConfig';
  *       prospects to the dev SQS queue to be consumed by the dev lambda and sent
  *       to the dev curation admin tool :D
  *
- * 2. Set up the event rule for the dismiss-prospect event.
+ * 2. Set up the SNS topic and Event Bridge rules for all of the other Prospect events. (prospect-dismiss event as of now)
  *
  * Note that this class behaves differently based on the environment to which
  * it was deployed!

--- a/.aws/src/event-rules/prospect-events/prospectEventRules.ts
+++ b/.aws/src/event-rules/prospect-events/prospectEventRules.ts
@@ -36,8 +36,8 @@ export class ProspectEvents extends Resource {
   readonly sqsIdForProspectGenerationEvent = `prospect-${config.environment}-queue`;
   readonly sqsNameForProspectGenerationEvent = `ProspectAPI-${config.environment}-Sqs-Translation-Queue`;
 
-  readonly dlqIdForProspectGenerationEvent = `prospect-${config.environment}-dlq`;
-  readonly dlqNameForProspectGenerationEvent = `ProspectAPI-${config.environment}-Sqs-Translation-Queue-Deadletter`;
+  readonly dlqIdForProspectEvents = `prospect-${config.environment}-dlq`;
+  readonly dlqNameForProspectEvents = `ProspectAPI-${config.environment}-Sqs-Translation-Queue-Deadletter`;
 
   readonly snsIdForProspectEvents = `prospect-event-topic`;
   readonly snsNameForProspectEvents = `${config.prefix}-ProspectEventTopic`;
@@ -57,8 +57,8 @@ export class ProspectEvents extends Resource {
 
     // create a dlq for all Prospect events
     this.sqsDlq = this.createSqsForProspectEvents(
-      this.dlqIdForProspectGenerationEvent,
-      this.dlqNameForProspectGenerationEvent
+      this.dlqIdForProspectEvents,
+      this.dlqNameForProspectEvents
     );
 
     // create an SNS topic for all Prospect events except for prospect-generation

--- a/.aws/src/event-rules/prospect-events/prospectEventRules.ts
+++ b/.aws/src/event-rules/prospect-events/prospectEventRules.ts
@@ -126,7 +126,7 @@ export class ProspectEvents extends Resource {
 
     const prospectEventRuleProps: PocketEventBridgeProps = {
       eventRule: {
-        name: `${config.prefix}-ProspectEvents-Rule`,
+        name: `${config.prefix}-Dismiss-Prospect-Events-Rule`,
         eventPattern: {
           source: [eventConfig.dismissProspect.source],
           'detail-type': eventConfig.dismissProspect.detailType,

--- a/.aws/src/event-rules/prospect-events/prospectEventRules.ts
+++ b/.aws/src/event-rules/prospect-events/prospectEventRules.ts
@@ -67,7 +67,7 @@ export class ProspectEvents extends Resource {
     this.createProspectGenerationEventRule();
     this.createPolicyForEventBridgeToSqs();
 
-    // setting up dismiss-prospect event rule
+    // setting up prospect-dismiss event rule
     this.createProspectEventRule(
       'Dismiss-Prospect-Events-Rule',
       eventConfig.prospectDismiss.source,
@@ -109,7 +109,7 @@ export class ProspectEvents extends Resource {
     name = this.snsNameForProspectEvents
   ): sns.SnsTopic {
     return new sns.SnsTopic(this, id, {
-      name: name,
+      name,
     });
   }
 

--- a/.aws/src/event-rules/prospect-events/prospectEventRules.ts
+++ b/.aws/src/event-rules/prospect-events/prospectEventRules.ts
@@ -33,6 +33,15 @@ export class ProspectEvents extends Resource {
   public readonly sqs: sqs.DataAwsSqsQueue;
   public readonly sqsDlq: sqs.DataAwsSqsQueue;
 
+  readonly sqsIdForProspectGenerationEvent = `prospect-${config.environment}-queue`;
+  readonly sqsNameForProspectGenerationEvent = `ProspectAPI-${config.environment}-Sqs-Translation-Queue`;
+
+  readonly dlqIdForProspectGenerationEvent = `prospect-${config.environment}-dlq`;
+  readonly dlqNameForProspectGenerationEvent = `ProspectAPI-${config.environment}-Sqs-Translation-Queue-Deadletter`;
+
+  readonly snsIdForProspectEvents = `prospect-event-topic`;
+  readonly snsNameForProspectEvents = `${config.prefix}-ProspectEventTopic`;
+
   constructor(
     scope: Construct,
     private name: string,
@@ -41,31 +50,30 @@ export class ProspectEvents extends Resource {
     super(scope, name);
 
     // pre-existing queues (prod and dev) created by prospect-api
-    this.sqs = new sqs.DataAwsSqsQueue(
-      this,
-      `prospect-${config.environment}-queue`,
-      {
-        name: `ProspectAPI-${config.environment}-Sqs-Translation-Queue`,
-      }
+    this.sqs = this.createSqsForProspectEvents(
+      this.sqsIdForProspectGenerationEvent,
+      this.sqsNameForProspectGenerationEvent
     );
 
-    this.sqsDlq = new sqs.DataAwsSqsQueue(
-      this,
-      `prospect-${config.environment}-dlq`,
-      {
-        name: `ProspectAPI-${config.environment}-Sqs-Translation-Queue-Deadletter`,
-      }
+    // create a dlq for all Prospect events
+    this.sqsDlq = this.createSqsForProspectEvents(
+      this.dlqIdForProspectGenerationEvent,
+      this.dlqNameForProspectGenerationEvent
     );
 
-    this.snsTopic = new sns.SnsTopic(this, 'prospect-event-topic', {
-      name: `${config.prefix}-ProspectEventTopic`,
-    });
+    // create an SNS topic for all Prospect events except for prospect-generation
+    this.snsTopic = this.createSnsForProspectEvents();
 
-    this.createProspectEventRules();
+    this.createProspectGenerationEventRule();
     this.createPolicyForEventBridgeToSqs();
 
-    // setting up dismiss-prospect event rule and setting the required IAM policies
-    this.createDismissProspectEventRule();
+    // setting up dismiss-prospect event rule
+    this.createProspectEventRule(
+      'Dismiss-Prospect-Events-Rule',
+      eventConfig.prospectDismiss.source,
+      eventConfig.prospectDismiss.detailType
+    );
+    // setting up the required IAM policies
     this.createPolicyForEventBridgeToSns();
 
     // TODO: create a policy function for dev event bridge
@@ -73,10 +81,44 @@ export class ProspectEvents extends Resource {
   }
 
   /**
-   * Create an event bridge rule and attach to the configured targets.
-   * @private
+   * Creates a SQS/DLQ.
+   * NOTE: The SQS will only be used by the prospect-generation events. The DLQ is shared and used by other Prospect events as well.
+   *
+   * @param id
+   * @param name
+   * @returns A queue (SQS/DLQ).
    */
-  private createProspectEventRules() {
+  private createSqsForProspectEvents(
+    id: string,
+    name: string
+  ): sqs.DataAwsSqsQueue {
+    return new sqs.DataAwsSqsQueue(this, id, {
+      name,
+    });
+  }
+
+  /**
+   * Creates the SNS topic that all Prospect events will publish to except for prospect-generation event.
+   *
+   * @param id default set to class variable: snsIdForProspectEvents. Shouldn't need to change it unless changing it for all prospect events that use this sns topic.
+   * @param name default set to class variable: snsNameForProspectEvents. Shouldn't need to change it unless changing it for all prospect events that use this sns topic.
+   * @returns A SNS topic that is used by all Prospect events except for prospect-generation events.
+   */
+  private createSnsForProspectEvents(
+    id = this.snsIdForProspectEvents,
+    name = this.snsNameForProspectEvents
+  ): sns.SnsTopic {
+    return new sns.SnsTopic(this, id, {
+      name: name,
+    });
+  }
+
+  /**
+   * Creates and sets up the required constructs needed for the prospect-generation event.
+   * NOTE: this is an unique event that has its own SQS and is not published to the SNS topic shared by all of the other Prospect events.
+   *       Hence, this function does not provide any parameters to customize event and construct attributes.
+   */
+  private createProspectGenerationEventRule() {
     // both prod and dev have an sqs target
     const targets: PocketEventBridgeTargets[] = [
       {
@@ -97,12 +139,12 @@ export class ProspectEvents extends Resource {
       });
     }
 
-    const prospectEventRuleProps: PocketEventBridgeProps = {
+    const prospectGenerationEventRuleProps: PocketEventBridgeProps = {
       eventRule: {
         name: `${config.prefix}-ProspectEvents-Rule`,
         eventPattern: {
-          source: [eventConfig.source],
-          'detail-type': eventConfig.detailType,
+          source: [eventConfig.prospectGeneration.source],
+          'detail-type': eventConfig.prospectGeneration.detailType,
         },
         eventBusName: this.sharedEventBus.bus.name,
       },
@@ -112,29 +154,37 @@ export class ProspectEvents extends Resource {
     new PocketEventBridgeRuleWithMultipleTargets(
       this,
       `${config.prefix}-Prospect-Prod-EventBridge-Rule`,
-      prospectEventRuleProps
+      prospectGenerationEventRuleProps
     );
   }
 
   /**
-   * Create an event bridge rule for the dismiss-prospect event. Note that this event rule uses a SNS topic.
+   * Create an event bridge rule for Prospect events.
+   *
+   * @param name
+   * @param source
+   * @param detailType
    */
-  private createDismissProspectEventRule() {
+  private createProspectEventRule(
+    name: string,
+    source: string,
+    detailType: string[]
+  ) {
     const targets: PocketEventBridgeTargets[] = [
       {
         arn: this.snsTopic.arn,
-        deadLetterArn: this.sqsDlq.arn, //using the same DLQ for all prospect events (prospect-generation and dismiss-prospect as of now)
+        deadLetterArn: this.sqsDlq.arn, //using the same DLQ for all prospect events (prospect-generation and prospect-dismiss as of now)
         targetId: `${config.prefix}-Prospect-Event-SNS-Target`,
         terraformResource: this.snsTopic,
       },
     ];
 
-    const dismissProspectEventRuleProps: PocketEventBridgeProps = {
+    const prospectEventRuleProps = {
       eventRule: {
-        name: `${config.prefix}-Dismiss-Prospect-Events-Rule`,
+        name: `${config.prefix}-${name}`,
         eventPattern: {
-          source: [eventConfig.dismissProspect.source],
-          'detail-type': eventConfig.dismissProspect.detailType,
+          source: [source],
+          'detail-type': detailType,
         },
         eventBusName: this.sharedEventBus.bus.name,
       },
@@ -143,8 +193,8 @@ export class ProspectEvents extends Resource {
 
     new PocketEventBridgeRuleWithMultipleTargets(
       this,
-      `${config.prefix}-Dismiss-Prospect-Prod-EventBridge-Rule`,
-      dismissProspectEventRuleProps
+      `${config.prefix}-${name}-Prod-EventBridge-Rule`,
+      prospectEventRuleProps
     );
   }
 
@@ -178,6 +228,9 @@ export class ProspectEvents extends Resource {
     });
   }
 
+  /**
+   * Create IAM policy to allow EventBridge to send messages to SQS for prospect-generation events.
+   */
   private createPolicyForEventBridgeToSqs() {
     const eventBridgeSqsPolicy = new iam.DataAwsIamPolicyDocument(
       this,

--- a/.aws/src/event-rules/prospect-events/prospectEventRules.ts
+++ b/.aws/src/event-rules/prospect-events/prospectEventRules.ts
@@ -70,8 +70,13 @@ export class ProspectEvents extends Resource {
 
     // only prod also targets the dev event bridge
     if (!config.isDev) {
-      // TODO: add dev event bridge target
       // https://docs.aws.amazon.com/eventbridge/latest/userguide/eb-cross-account.html
+      // note that permissions have been added by hand to the dev event bus to
+      // allow it to receive events from the prod bus.
+      targets.push({
+        arn: 'arn:aws:events:us-east-1:410318598490:event-bus/PocketEventBridge-Dev-Shared-Event-Bus',
+        targetId: `${config.prefix}-Prospect-Event-Dev-Event-Bridget-Target`
+      })
     }
 
     const prospectEventRuleProps: PocketEventBridgeProps = {

--- a/.aws/src/event-rules/user-api-events/eventConfig.ts
+++ b/.aws/src/event-rules/user-api-events/eventConfig.ts
@@ -1,4 +1,4 @@
 export const eventConfig = {
   source: 'user-events',
-  detailType: ['account-deletion'],
+  detailType: ['account-deletion', 'account-email-updated'],
 };


### PR DESCRIPTION
## Goal
Set up the event rule for `dismiss-prospect` event. 

We're setting up a SNS topic for this event rule to which the Event Bridge will publish to.

[Dev deployment of the rule](https://us-east-1.console.aws.amazon.com/events/home?region=us-east-1#/schemas)

JIRA ticket:
* [BACK-1623]


[BACK-1623]: https://getpocket.atlassian.net/browse/BACK-1623?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ