### PR TITLE
chore(prospect-events-alert): disabling DLQ low alert temporarily 

### DIFF
--- a/.aws/src/event-rules/prospect-events/prospectEventRules.ts
+++ b/.aws/src/event-rules/prospect-events/prospectEventRules.ts
@@ -83,12 +83,15 @@ export class ProspectEvents extends Resource {
     // TODO: create a policy function for dev event bridge
     // this.createPolicyForEventBridgeToDevEventBridge();
 
-    createDeadLetterQueueAlarm(
-      this,
-      pagerDuty,
-      this.sqsDlq.name,
-      `${eventConfig.name}-Rule-DLQ-Alarm`
-    );
+    //todo: disabling till this ticket is done:
+    //https://getpocket.atlassian.net/browse/INFRA-1048
+    //prospect-alert triggering false alert for 1 message in the DLQ
+    // createDeadLetterQueueAlarm(
+    //   this,
+    //   pagerDuty,
+    //   this.sqsDlq.name,
+    //   `${eventConfig.name}-Rule-DLQ-Alarm`
+    // );
 
     new NullProviders.Resource(this, 'null-resource', {
       dependsOn: [


### PR DESCRIPTION
## Goal
the alert has been triggered since yesterday as there is one event failed instead of 15+ and generating false alert
we should investigate why the DLQ alert is failing (may be have a different metric than Approx.NoOfMessasgesVisible)

ticket for this: https://getpocket.atlassian.net/browse/INFRA-1048

in the meantime, disabling this alert for prospect-events

slack discussion: https://pocket.slack.com/archives/C016NAMSW2J/p1676501867786539

[DLQ prod link with 1 message](https://us-east-1.console.aws.amazon.com/sqs/v2/home?region=us-east-1#/queues/https%3A%2F%2Fsqs.us-east-1.amazonaws.com%2F996905175585%2FProspectAPI-Prod-Sqs-Translation-Queue-Deadletter)


