### PR TITLE
Disable prospect dlq alarm via aws

### DIFF
--- a/.aws/src/event-rules/prospect-events/prospectEventRules.ts
+++ b/.aws/src/event-rules/prospect-events/prospectEventRules.ts
@@ -86,12 +86,13 @@ export class ProspectEvents extends Resource {
     //todo: disabling till this ticket is done:
     //https://getpocket.atlassian.net/browse/INFRA-1048
     //prospect-alert triggering false alert for 1 message in the DLQ
-    // createDeadLetterQueueAlarm(
-    //   this,
-    //   pagerDuty,
-    //   this.sqsDlq.name,
-    //   `${eventConfig.name}-Rule-DLQ-Alarm`
-    // );
+    createDeadLetterQueueAlarm(
+      this,
+      pagerDuty,
+      this.sqsDlq.name,
+      `${eventConfig.name}-Rule-DLQ-Alarm`,
+      false // temporarily disabled, see note above
+    );
 
     new NullProviders.Resource(this, 'null-resource', {
       dependsOn: [

--- a/.aws/src/event-rules/prospect-events/prospectEventRules.ts
+++ b/.aws/src/event-rules/prospect-events/prospectEventRules.ts
@@ -83,12 +83,15 @@ export class ProspectEvents extends Resource {
     // TODO: create a policy function for dev event bridge
     // this.createPolicyForEventBridgeToDevEventBridge();
 
-    createDeadLetterQueueAlarm(
-      this,
-      pagerDuty,
-      this.sqsDlq.name,
-      `${eventConfig.name}-Rule-DLQ-Alarm`
-    );
+    //todo: disabling till this ticket is done:
+    //https://getpocket.atlassian.net/browse/INFRA-1048
+    //prospect-alert triggering false alert for 1 message in the DLQ
+    // createDeadLetterQueueAlarm(
+    //   this,
+    //   pagerDuty,
+    //   this.sqsDlq.name,
+    //   `${eventConfig.name}-Rule-DLQ-Alarm`
+    // );
 
     new NullProviders.Resource(this, 'null-resource', {
       dependsOn: [

--- a/.aws/src/event-rules/user-api-events/userApiEventRules.ts
+++ b/.aws/src/event-rules/user-api-events/userApiEventRules.ts
@@ -45,6 +45,7 @@ export class UserApiEvents extends Resource {
       pagerDuty,
       this.snsTopicDlq.name,
       `${eventConfig.name}-Rule-dlq-alarm`,
+      true,
       4,
       300,
       10

--- a/.aws/src/event-rules/utils.ts
+++ b/.aws/src/event-rules/utils.ts
@@ -14,6 +14,7 @@ import { PocketPagerDuty } from '@pocket-tools/terraform-modules';
  * @param evaluationPeriods
  * @param periodInSeconds
  * @param threshold
+ * @param enabled if alarm should act on state changes (pass/fail), defaults to true
  * @private
  */
 export function createDeadLetterQueueAlarm(
@@ -21,6 +22,7 @@ export function createDeadLetterQueueAlarm(
   pagerDuty: PocketPagerDuty,
   queueName: string,
   alarmName: string,
+  enabled: boolean = true,
   evaluationPeriods = 2,
   periodInSeconds = 900,
   threshold = 15
@@ -38,5 +40,6 @@ export function createDeadLetterQueueAlarm(
     statistic: 'Sum',
     alarmActions: config.isDev ? [] : [pagerDuty.snsNonCriticalAlarmTopic.arn],
     okActions: config.isDev ? [] : [pagerDuty.snsNonCriticalAlarmTopic.arn],
+    actionsEnabled: enabled,
   });
 }


### PR DESCRIPTION
## Goal

An alternative implementation to #104 - add option to disable a Cloudwatch alarm (so the alarm still exists / tracks state, but does nothing upon state changes), and use it for a broken alarm.
