### PR TITLE
OSL-211: Adding shareable-lists-api events

### DIFF
--- a/.aws/src/event-rules/shareable-lists-api-events/eventConfig.ts
+++ b/.aws/src/event-rules/shareable-lists-api-events/eventConfig.ts
@@ -1,0 +1,5 @@
+export const eventConfig = {
+  name: 'ShareableListsApiEvents',
+  source: 'shareable-lists-api-events',
+  detailType: ['shareable_list', 'shareable_list_item'],
+};

--- a/.aws/src/event-rules/shareable-lists-api-events/shareableListsApiEventRules.ts
+++ b/.aws/src/event-rules/shareable-lists-api-events/shareableListsApiEventRules.ts
@@ -1,0 +1,127 @@
+import { Construct } from 'constructs';
+import { Resource } from 'cdktf';
+import {
+  PocketEventBridgeProps,
+  PocketEventBridgeRuleWithMultipleTargets,
+  ApplicationEventBus,
+  PocketPagerDuty,
+} from '@pocket-tools/terraform-modules';
+import { config } from '../../config';
+import { iam, sns, sqs } from '@cdktf/provider-aws';
+import { eventConfig } from './eventConfig';
+import { createDeadLetterQueueAlarm } from '../utils';
+import * as NullProviders from '@cdktf/provider-null';
+
+export class ShareableListsApiEvents extends Resource {
+  public readonly snsTopic: sns.SnsTopic;
+  public readonly snsTopicDlq: sqs.SqsQueue;
+
+  constructor(
+    scope: Construct,
+    private name: string,
+    private sharedEventBus: ApplicationEventBus,
+    private pagerDuty: PocketPagerDuty
+  ) {
+    super(scope, name);
+
+    this.snsTopic = new sns.SnsTopic(this, 'shareable-lists-api-event-topic', {
+      name: `${config.prefix}-ShareableListsApiEventTopic`,
+      lifecycle: {
+        preventDestroy: true,
+      },
+    });
+
+    this.snsTopicDlq = new sqs.SqsQueue(this, 'sns-topic-dql', {
+      name: `${config.prefix}-SNS-Topic-Event-Rule-DLQ`,
+      tags: config.tags,
+    });
+
+    const slapiEvent = this.createShareableListsApiEventRules();
+    this.createPolicyForEventBridgeToSns();
+
+    //get alerted if we get 10 messages in DLQ in 4 evaluation period of 5 minutes
+    createDeadLetterQueueAlarm(
+      this,
+      pagerDuty,
+      this.snsTopicDlq.name,
+      `${eventConfig.name}-Rule-dlq-alarm`,
+      true,
+      4,
+      300,
+      10
+    );
+
+    //place-holder resource used to make sure we are not
+    //removing the event-rule or the SNS by mistake
+    //if the resources are removed, this would act as an additional check
+    //to prevent resource deletion in-addition to preventDestroy
+    //e.g removing any of the dependsOn resource and running npm build would
+    //throw error
+    new NullProviders.Resource(this, 'null-resource', {
+      dependsOn: [slapiEvent.getEventBridge().rule, this.snsTopic],
+    });
+  }
+
+  /**
+   * Rolls out event bridge rule and attaches them to sns target
+   * for slapi-events
+   * @private
+   */
+  private createShareableListsApiEventRules() {
+    const slapiEventRuleProps: PocketEventBridgeProps = {
+      eventRule: {
+        name: `${config.prefix}-${eventConfig.name}-Rule`,
+        eventPattern: {
+          source: [eventConfig.source],
+          'detail-type': eventConfig.detailType,
+        },
+        eventBusName: this.sharedEventBus.bus.name,
+        preventDestroy: true,
+      },
+      targets: [
+        {
+          arn: this.snsTopic.arn,
+          deadLetterArn: this.snsTopicDlq.arn,
+          targetId: `${config.prefix}-Shareable-Lists-Api-Event-SNS-Target`,
+          terraformResource: this.snsTopic,
+        },
+      ],
+    };
+    return new PocketEventBridgeRuleWithMultipleTargets(
+      this,
+      `${config.prefix}-Shareable-Lists-Api-EventBridge-Rule`,
+      slapiEventRuleProps
+    );
+  }
+
+  private createPolicyForEventBridgeToSns() {
+    const eventBridgeSnsPolicy = new iam.DataAwsIamPolicyDocument(
+      this,
+      `${config.prefix}-EventBridge-SNS-Policy`,
+      {
+        statement: [
+          {
+            effect: 'Allow',
+            actions: ['sns:Publish'],
+            resources: [this.snsTopic.arn],
+            principals: [
+              {
+                identifiers: ['events.amazonaws.com'],
+                type: 'Service',
+              },
+            ],
+          },
+        ],
+      }
+    ).json;
+
+    return new sns.SnsTopicPolicy(
+      this,
+      'shareable-lists-api-events-sns-topic-policy',
+      {
+        arn: this.snsTopic.arn,
+        policy: eventBridgeSnsPolicy,
+      }
+    );
+  }
+}

--- a/.aws/src/main.ts
+++ b/.aws/src/main.ts
@@ -16,6 +16,7 @@ import {
 import { UserApiEvents } from './event-rules/user-api-events/userApiEventRules';
 import { ProspectEvents } from './event-rules/prospect-events/prospectEventRules';
 import { CollectionApiEvents } from './event-rules/collection-events/collectionApiEventRules';
+import { ShareableListsApiEvents } from './event-rules/shareable-lists-api-events/shareableListsApiEventRules';
 import { PocketPagerDuty, PocketVPC } from '@pocket-tools/terraform-modules';
 import { ArchiveProvider } from '@cdktf/provider-archive';
 import { config } from './config';
@@ -99,6 +100,14 @@ class PocketEventBus extends TerraformStack {
       pagerDuty
     );
     //TODO add collection events open api schema from aws
+
+    // Events for Shareable Lists API service
+    new ShareableListsApiEvents(
+      this,
+      'shareable-lists-api-events',
+      sharedPocketEventBus,
+      pagerDuty
+    );
   }
 
   /**


### PR DESCRIPTION
## Goal

Creating a new event bridge rule for `shareable-lists-api` events.

JIRA ticket:
* [https://getpocket.atlassian.net/browse/OSL-211](https://getpocket.atlassian.net/browse/OSL-211)
