### PR TITLE
OSL-226: splitting shareable-lists-api events into separate new event bridge rule 

### DIFF
--- a/.aws/src/event-rules/shareable-lists-api-events/eventConfig.ts
+++ b/.aws/src/event-rules/shareable-lists-api-events/eventConfig.ts
@@ -1,5 +1,17 @@
 export const eventConfig = {
-  name: 'ShareableListsApiEvents',
-  source: 'shareable-lists-api-events',
-  detailType: ['shareable_list', 'shareable_list_item'],
+  shareableList: {
+    name: 'ShareableListEvents',
+    source: 'shareable-list-events',
+    detailType: [
+      'shareable-list-created',
+      'shareable-list-updated',
+      'shareable-list-deleted',
+      'shareable-list-hidden',
+    ],
+  },
+  shareableListItem: {
+    name: 'ShareableListItemEvents',
+    source: 'shareable-list-item-events',
+    detailType: ['shareable-list-item-created', 'shareable-list-item-deleted'],
+  },
 };

--- a/.aws/src/event-rules/shareable-lists-api-events/shareableListEventRules.ts
+++ b/.aws/src/event-rules/shareable-lists-api-events/shareableListEventRules.ts
@@ -1,0 +1,127 @@
+import { Construct } from 'constructs';
+import { Resource } from 'cdktf';
+import {
+  PocketEventBridgeProps,
+  PocketEventBridgeRuleWithMultipleTargets,
+  ApplicationEventBus,
+  PocketPagerDuty,
+} from '@pocket-tools/terraform-modules';
+import { config } from '../../config';
+import { iam, sns, sqs } from '@cdktf/provider-aws';
+import { eventConfig } from './eventConfig';
+import { createDeadLetterQueueAlarm } from '../utils';
+import * as NullProviders from '@cdktf/provider-null';
+
+export class ShareableListEvents extends Resource {
+  public readonly snsTopic: sns.SnsTopic;
+  public readonly snsTopicDlq: sqs.SqsQueue;
+
+  constructor(
+    scope: Construct,
+    private name: string,
+    private sharedEventBus: ApplicationEventBus,
+    private pagerDuty: PocketPagerDuty
+  ) {
+    super(scope, name);
+
+    this.snsTopic = new sns.SnsTopic(this, 'shareable-list-event-topic', {
+      name: `${config.prefix}-ShareableListEventTopic`,
+      lifecycle: {
+        preventDestroy: true,
+      },
+    });
+
+    this.snsTopicDlq = new sqs.SqsQueue(this, 'sns-topic-dql', {
+      name: `${config.prefix}-SNS-Topic-Event-Rule-DLQ`,
+      tags: config.tags,
+    });
+
+    const shareableListEvent = this.createShareableListEventRules();
+    this.createPolicyForEventBridgeToSns();
+
+    //get alerted if we get 10 messages in DLQ in 4 evaluation period of 5 minutes (for shareable-list)
+    createDeadLetterQueueAlarm(
+      this,
+      pagerDuty,
+      this.snsTopicDlq.name,
+      `${eventConfig.shareableList.name}-Rule-dlq-alarm`,
+      true,
+      4,
+      300,
+      10
+    );
+
+    //place-holder resource used to make sure we are not
+    //removing the event-rule or the SNS by mistake
+    //if the resources are removed, this would act as an additional check
+    //to prevent resource deletion in-addition to preventDestroy
+    //e.g removing any of the dependsOn resource and running npm build would
+    //throw error
+    new NullProviders.Resource(this, 'null-resource', {
+      dependsOn: [shareableListEvent.getEventBridge().rule, this.snsTopic],
+    });
+  }
+
+  /**
+   * Rolls out event bridge rule and attaches them to sns target
+   * for shareable-list-events
+   * @private
+   */
+  private createShareableListEventRules() {
+    const shareableListEventRuleProps: PocketEventBridgeProps = {
+      eventRule: {
+        name: `${config.prefix}-${eventConfig.shareableList.name}-Rule`,
+        eventPattern: {
+          source: [eventConfig.shareableList.source],
+          'detail-type': eventConfig.shareableList.detailType,
+        },
+        eventBusName: this.sharedEventBus.bus.name,
+        preventDestroy: true,
+      },
+      targets: [
+        {
+          arn: this.snsTopic.arn,
+          deadLetterArn: this.snsTopicDlq.arn,
+          targetId: `${config.prefix}-Shareable-List-Event-SNS-Target`,
+          terraformResource: this.snsTopic,
+        },
+      ],
+    };
+    return new PocketEventBridgeRuleWithMultipleTargets(
+      this,
+      `${config.prefix}-Shareable-List-EventBridge-Rule`,
+      shareableListEventRuleProps
+    );
+  }
+
+  private createPolicyForEventBridgeToSns() {
+    const eventBridgeSnsPolicy = new iam.DataAwsIamPolicyDocument(
+      this,
+      `${config.prefix}-EventBridge-SNS-Policy`,
+      {
+        statement: [
+          {
+            effect: 'Allow',
+            actions: ['sns:Publish'],
+            resources: [this.snsTopic.arn],
+            principals: [
+              {
+                identifiers: ['events.amazonaws.com'],
+                type: 'Service',
+              },
+            ],
+          },
+        ],
+      }
+    ).json;
+
+    return new sns.SnsTopicPolicy(
+      this,
+      'shareable-list-events-sns-topic-policy',
+      {
+        arn: this.snsTopic.arn,
+        policy: eventBridgeSnsPolicy,
+      }
+    );
+  }
+}

--- a/.aws/src/main.ts
+++ b/.aws/src/main.ts
@@ -16,7 +16,8 @@ import {
 import { UserApiEvents } from './event-rules/user-api-events/userApiEventRules';
 import { ProspectEvents } from './event-rules/prospect-events/prospectEventRules';
 import { CollectionApiEvents } from './event-rules/collection-events/collectionApiEventRules';
-import { ShareableListsApiEvents } from './event-rules/shareable-lists-api-events/shareableListsApiEventRules';
+import { ShareableListEvents } from './event-rules/shareable-lists-api-events/shareableListEventRules';
+import { ShareableListItemEvents } from './event-rules/shareable-lists-api-events/shareableListItemEventRules';
 import { PocketPagerDuty, PocketVPC } from '@pocket-tools/terraform-modules';
 import { ArchiveProvider } from '@cdktf/provider-archive';
 import { config } from './config';
@@ -101,10 +102,18 @@ class PocketEventBus extends TerraformStack {
     );
     //TODO add collection events open api schema from aws
 
-    // Events for Shareable Lists API service
-    new ShareableListsApiEvents(
+    // Shareable List Events for Shareable Lists API service
+    new ShareableListEvents(
       this,
-      'shareable-lists-api-events',
+      'shareable-list-events',
+      sharedPocketEventBus,
+      pagerDuty
+    );
+
+    // Shareable List Item Events for Shareable Lists API service
+    new ShareableListItemEvents(
+      this,
+      'shareable-list-item-events',
       sharedPocketEventBus,
       pagerDuty
     );


### PR DESCRIPTION
## Goal

We are sending two separate events from `shareable-lists-api` (`shareable-list` and `shareable-list-item`) so it was decided to create separate event bridge rules for each event.

JIRA ticket:
* [https://getpocket.atlassian.net/browse/OSL-226](https://getpocket.atlassian.net/browse/OSL-226)