### PR TITLE
OSL-244: adding shareable-list publish and unpublish triggers for event rule mapping for shareable-list

### DIFF
--- a/.aws/src/event-rules/shareable-lists-api-events/eventConfig.ts
+++ b/.aws/src/event-rules/shareable-lists-api-events/eventConfig.ts
@@ -7,6 +7,8 @@ export const eventConfig = {
       'shareable-list-updated',
       'shareable-list-deleted',
       'shareable-list-hidden',
+      'shareable-list-published',
+      'shareable-list-unpublished',
     ],
   },
   shareableListItem: {


### PR DESCRIPTION
## Goal
The `object_update` snowplow schema now has the `shareable-list-publish` and `shareable-list-unpublish` triggers. Adding shareable-list publish and unpublish triggers for event rule mapping for shareable-list

## JIRA ticket:
* [https://getpocket.atlassian.net/browse/OSL-244](https://getpocket.atlassian.net/browse/OSL-244)
