### PR TITLE
OSL-397-OSL-473: adding new triggers for shareable-lists-api

### DIFF
--- a/.aws/src/event-rules/shareable-lists-api-events/eventConfig.ts
+++ b/.aws/src/event-rules/shareable-lists-api-events/eventConfig.ts
@@ -7,6 +7,7 @@ export const eventConfig = {
       'shareable_list_updated',
       'shareable_list_deleted',
       'shareable_list_hidden',
+      'shareable_list_unhidden',
       'shareable_list_published',
       'shareable_list_unpublished',
     ],
@@ -14,6 +15,10 @@ export const eventConfig = {
   shareableListItem: {
     name: 'ShareableListItemEvents',
     source: 'shareable-list-item-events',
-    detailType: ['shareable_list_item_created', 'shareable_list_item_deleted'],
+    detailType: [
+      'shareable_list_item_created',
+      'shareable_list_item_updated',
+      'shareable_list_item_deleted',
+    ],
   },
 };


### PR DESCRIPTION
## Goal

Adding `shareable_list_unhidden` trigger and `shareable_list_item_updated` trigger to shareable-lists-api event config.

 ## JIRA ticket:

* https://getpocket.atlassian.net/browse/OSL-397
* https://getpocket.atlassian.net/browse/OSL-473