### PR TITLE
fix(user-merge): point user merge events to pocket shared bus

### DIFF
--- a/.aws/src/event-rules/account-delete-monitor/config.ts
+++ b/.aws/src/event-rules/account-delete-monitor/config.ts
@@ -5,6 +5,7 @@ export const config = {
     scheduleExpression: 'cron(15 10 * * ? *)', // 03:15 PT every day
     name: 'EventTracker',
     schema: 'queue-check-delete',
+    //scheduled events are supported by default bus only.
     bus: 'default',
   },
   userMerge: {

--- a/.aws/src/event-rules/account-delete-monitor/config.ts
+++ b/.aws/src/event-rules/account-delete-monitor/config.ts
@@ -14,7 +14,7 @@ export const config = {
     //todo: swap after replaying events.
     source: 'user-merge',
     detailType: ['web-repo'],
-    bus: `default`, //todo: change it to shared-event-bridge after changing in web-repo
+    bus: globalConfig.sharedEventBusName,
   },
   prefix: `AccountDeleteMonitor-${globalConfig.environment}`,
 };

--- a/.aws/src/event-rules/account-delete-monitor/index.ts
+++ b/.aws/src/event-rules/account-delete-monitor/index.ts
@@ -106,7 +106,7 @@ export class AccountDeleteMonitorEvents extends Resource {
           'detail-type': admConfig.userMerge.detailType,
         },
         eventBusName: admConfig.userMerge.bus,
-        preventDestroy: true,
+        preventDestroy: false,
       },
       targets: [
         {

--- a/.aws/src/event-rules/shareable-lists-api-events/eventConfig.ts
+++ b/.aws/src/event-rules/shareable-lists-api-events/eventConfig.ts
@@ -7,6 +7,7 @@ export const eventConfig = {
       'shareable_list_updated',
       'shareable_list_deleted',
       'shareable_list_hidden',
+      'shareable_list_unhidden',
       'shareable_list_published',
       'shareable_list_unpublished',
     ],
@@ -14,6 +15,10 @@ export const eventConfig = {
   shareableListItem: {
     name: 'ShareableListItemEvents',
     source: 'shareable-list-item-events',
-    detailType: ['shareable_list_item_created', 'shareable_list_item_deleted'],
+    detailType: [
+      'shareable_list_item_created',
+      'shareable_list_item_updated',
+      'shareable_list_item_deleted',
+    ],
   },
 };


### PR DESCRIPTION
## Goal
noticed that we have moved user-merge events in web repo but have not addressed the TODO to point the event rules to shared event bus

slack conversation: https://pocket.slack.com/archives/C03QVL4SU/p1685983254936209?thread_ts=1685976290.416629&cid=C03QVL4SU

web repo emitting to shared bus code: https://github.com/Pocket/Web/blob/58390709f6b3dfed4d94c305fc1edbb5268e270c/src/EventBridge/PocketEventBus.php#L65

consumer - account-delete monitor that deletes old events

## feedback on
- prevent destroy is set to true for user-merge event rule and this breaks the production terraform plan. can i manually delete `user-merge` event  and re-run the plan?